### PR TITLE
adding button for status filter

### DIFF
--- a/pages/history/index.tsx
+++ b/pages/history/index.tsx
@@ -1,19 +1,30 @@
 import React from "react";
 import { GetServerSideProps } from "next";
-import { Users } from "../../data/types/users";
+import { Exchange, Users } from "../../data/types/users";
 import { Props } from "../../data/types/props";
 import { checkingConnection } from "../../util/checkingConnection";
-import { Container, TableContainer } from "@material-ui/core";
+import { Container, TableContainer, Grid } from "@material-ui/core";
 import TableHeader from "./component/tableHeader";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
 import TableRow from "@material-ui/core/TableRow";
 import TableCell from "@material-ui/core/TableCell";
 import Paper from "@material-ui/core/Paper";
+import Button from "@material-ui/core/Button";
+import Link from "next/link";
 
 const History: React.FC<Props> = ({ userData }) => {
   const [orderDirection, setOrderDirection] = React.useState("");
   const [valueToOrderBy, setValueToOrderBy] = React.useState("");
+  const [selectStatus, setSelectStatus] = React.useState("All");
+  const [selectData, setSelectData] = React.useState<Exchange[]>(
+    userData.exchange.filter((element) => {
+      if (element.status === "Pending") {
+        return element;
+      }
+    })
+  );
+  const [defaultStatus, setDefaultStatus] = React.useState(userData.exchange);
 
   const handleRequestSort = (event, property) => {
     const isAscending = valueToOrderBy === property && orderDirection === "asc";
@@ -47,9 +58,98 @@ const History: React.FC<Props> = ({ userData }) => {
     return stabilizedRowArray.map((el) => el[0]);
   };
 
+  React.useEffect(() => {
+    const data: Exchange[] = userData.exchange.filter((element) => {
+      if (element.status === selectStatus) {
+        return element;
+      } else if (selectStatus === "All") {
+        return element;
+      }
+    });
+    setSelectData(data);
+  }, [selectStatus, defaultStatus]);
+  // console.log(selectData);
+
   return (
     <>
       <Container maxWidth="lg">
+        <Grid container>
+          <Grid item xs={2}>
+            <Button
+              onClick={() => {
+                setSelectStatus("All");
+              }}
+              variant="contained"
+              color="primary"
+            >
+              All
+            </Button>
+          </Grid>
+
+          <Grid item xs={2}>
+            <Button
+              onClick={() => {
+                setSelectStatus("Waiting");
+              }}
+              variant="contained"
+              color="primary"
+            >
+              Waiting
+            </Button>
+          </Grid>
+
+          <Grid item xs={2}>
+            <Button
+              onClick={() => {
+                setSelectStatus("Pending");
+              }}
+              variant="contained"
+              color="primary"
+            >
+              Pending
+            </Button>
+          </Grid>
+
+          <Grid item xs={2}>
+            <Button
+              onClick={() => {
+                setSelectStatus("Returned");
+              }}
+              variant="contained"
+              color="primary"
+            >
+              Returned
+            </Button>
+          </Grid>
+
+          <Grid item xs={2}>
+            <Button
+              onClick={() => {
+                setSelectStatus("Not returned");
+              }}
+              variant="contained"
+              color="primary"
+            >
+              Not returned
+            </Button>
+          </Grid>
+
+          <Grid item xs={2}>
+            <Button
+              onClick={() => {
+                setSelectStatus("Abort");
+              }}
+              variant="contained"
+              color="primary"
+            >
+              Abort
+            </Button>
+          </Grid>
+
+          <br />
+          <br />
+        </Grid>
+
         <TableContainer component={Paper}>
           <Table aria-label="simple table">
             <TableHeader
@@ -59,7 +159,7 @@ const History: React.FC<Props> = ({ userData }) => {
             />
             <TableBody>
               {sortedRowInformation(
-                userData.exchange,
+                selectData,
                 getComparator(orderDirection, valueToOrderBy)
               ).map((data, index) => (
                 <TableRow key={index}>


### PR DESCRIPTION
**### History** 

We add button to filter the exchange by status when the user click on a status button we display only all the associated status 
By default when we arrive to the history pages all exchanges are display
